### PR TITLE
Derive path prefix automatically and remove redundant mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,21 +53,22 @@ Jump right in to building Kibana prototypes with [EUI](https://github.com/elasti
 
     Open the `my-eui-starter` directory in your code editor of choice and edit `src/pages/index.tsx`. Save your changes and the browser will update in real time!
 
-1. **Deploy your site to GitHub pages**
+1. **Deploy your site to GitHub Pages**
 
-    When you're ready to deploy and share your site, you can use the provided `yarn build-docs` script to do so. The first time you do this, you need to do some preparation:
+    When you're ready to deploy and share your site to GitHub Pages, you can use the provided `yarn build-docs` script to do so. The first time you do this, you need to do some preparation:
 
-    1. Modify the `pathPrefix` option in `next.config.js` to reflect the name of your GitHub repo
-    1. Commit the above change
-    2. Create the GitHub pages branch: `git branch gh-pages`
+    1. (Optional) If you need to, set the `pathPrefix` option in `next.config.js` to reflect the name of your GitHub repo. The starter kit will try to derive this itself, so you're unlikely to see to do anything here.
+    1. (Optional) Commit the above change
+    1. Create the GitHub pages branch: `git branch gh-pages`
 
     Then whenever you want to update your site:
 
     1. Commit any pending changes
     1. Run `yarn build-docs`
     1. Publish the `master` and `gh-pages` branches by pushing them to GitHub: `git push origin master gh-pages`
-    1. Edit your repository settings to ensure your repository is configured so that the `gh-pages` branch is used for serving the site. (You only need to do this once, but you that you have to push the branch before you can change this setting)
-    1. Access your site at https://your-username.github.io/repo-name
+    1. Edit your repository settings to ensure your repository is configured so that the `gh-pages` branch is used for serving the site. (You only need to do this once, but you have to push the branch before you can change this setting)
+    1. Access your site at https://your-username.github.io/repo-name. There
+       can be a slight delay before changes become visible.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   Elastic's Next.js EUI Starter
 </h1>
 
-Jump right in to building Kibana prototypes with [EUI](https://github.com/elastic/eui).
+Jump right in to building prototypes with [EUI](https://github.com/elastic/eui).
 
 ## 🚀 Super-quick start using CodeSandbox
 
@@ -83,7 +83,6 @@ A quick look at the top-level files and directories you'll see in this project.
     ├── .prettierrc
     ├── LICENSE
     ├── README.md
-    ├── docs/
     ├── next.config.js
     ├── node_modules/
     ├── package.json
@@ -104,21 +103,19 @@ A quick look at the top-level files and directories you'll see in this project.
 
 6.  **`README.md`**: A text file containing useful reference information about your project.
 
-7.  **`docs/`**: When you build your project so that it can be shared, this is where the final result is generated.
+7.  **`next.config.js`**: This file customizes the Next.js build process so that it can work with EUI.
 
-8.  **`next.config.js`**: This file customizes the Next.js build process so that it can work with EUI.
+8.  **`node_modules/`**: This directory contains all of the modules of code that your project depends on (npm packages) are automatically installed.
 
-9.  **`node_modules/`**: This directory contains all of the modules of code that your project depends on (npm packages) are automatically installed.
+9. **`package.json`**: A manifest file for Node.js projects, which includes things like metadata (the project’s name, author, etc). This manifest is how npm knows which packages to install for your project.
 
-10. **`package.json`**: A manifest file for Node.js projects, which includes things like metadata (the project’s name, author, etc). This manifest is how npm knows which packages to install for your project.
+10. **`public/`**: Files that will never change can be put here. This starter project automatically puts EUI theme files here during the build
 
-11. **`public/`**: Files that will never change can be put here. This starter project automatically puts EUI theme files here during the build
+11. **`src/`**: This directory will contain all of the code related to what you will see on the front-end of your site (what you see in the browser) such as your site header or a page template. `src` is a convention for “source code”.
 
-12. **`src/`**: This directory will contain all of the code related to what you will see on the front-end of your site (what you see in the browser) such as your site header or a page template. `src` is a convention for “source code”.
+12. **`tsconfig.json`**: This file configures the [TypeScript](https://www.typescriptlang.org/) compiler
 
-13. **`tsconfig.json`**: This file configures the [TypeScript](https://www.typescriptlang.org/) compiler
-
-14. **`yarn.lock`** (See `package.json` below, first). This is an automatically generated file based on the exact versions of your npm dependencies that were installed for your project. **(You won’t change this file directly, but you need to commit any changes to git).**
+13. **`yarn.lock`** (See `package.json` below, first). This is an automatically generated file based on the exact versions of your npm dependencies that were installed for your project. **(You won’t change this file directly, but you need to commit any changes to git).**
 
 ## 🎓 Learning Next.js
 

--- a/next.config.js
+++ b/next.config.js
@@ -263,7 +263,7 @@ function hashFile(filePath) {
  * repository name is what will be used to serve the site.
  */
 function derivePathPrefix() {
-  const gitConfigPath = path.join('.git', 'config');
+  const gitConfigPath = path.join(__dirname, '.git', 'config');
 
   if (fs.existsSync(gitConfigPath)) {
     const gitConfig = iniparser.parseSync(gitConfigPath);
@@ -276,9 +276,7 @@ function derivePathPrefix() {
     }
   }
 
-  // path.join('.', 'package.json') seems to throw away the '.' path, which means
-  // that Node tries to load a "package.json" module, and that doesn't exist.
-  const packageJsonPath = '.' + path.sep + 'package.json';
+  const packageJsonPath = path.join(__dirname, 'package.json');
 
   if (fs.existsSync(packageJsonPath)) {
     const { name: packageName } = require(packageJsonPath);

--- a/next.config.js
+++ b/next.config.js
@@ -213,7 +213,9 @@ function buildThemeConfig() {
     const publicPath = `themes/${basename}.${hashFile(each)}.min.css`;
     const toPath = path.join(
       __dirname,
-      `public/themes/${basename}.${hashFile(each)}.min.css`
+      `public`,
+      `themes`,
+      `${basename}.${hashFile(each)}.min.css`
     );
 
     themeConfig.availableThemes.push({

--- a/next.config.js
+++ b/next.config.js
@@ -85,7 +85,7 @@ const nextConfig = {
         use: 'null-loader',
       });
 
-      // Mock HTMLElement, window and localStorage on the server-side
+      // Mock HTMLElement on the server-side
       const definePluginId = config.plugins.findIndex(
         p => p.constructor.name === 'DefinePlugin'
       );
@@ -93,20 +93,6 @@ const nextConfig = {
       config.plugins[definePluginId].definitions = {
         ...config.plugins[definePluginId].definitions,
         HTMLElement: function () {},
-
-        window: function () {},
-
-        // This definition allows localStorage to be called, but it stores
-        // nothing.
-        localStorage: {
-          getItem: function () {
-            return null;
-          },
-
-          setItem: function () {
-            return;
-          },
-        },
       };
     }
 
@@ -114,7 +100,8 @@ const nextConfig = {
     config.plugins.push(
       new CopyWebpackPlugin({ patterns: themeConfig.copyConfig }),
 
-      // We don't want to load all highlight.js language - provide a mechanism to register just some
+      // We don't want to load all highlight.js language - provide a mechanism to register just some.
+      // If you need to highlight more than just JSON, edit the file below.
       new NormalModuleReplacementPlugin(
         /^highlight\.js$/,
         path.join(__dirname, `src/lib/highlight.ts`)

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-react-hooks": "^4.0.2",
+    "iniparser": "^1.0.5",
     "null-loader": "^4.0.0",
     "prettier": "^2.0.5",
     "typescript": "^3.9.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4712,6 +4712,11 @@ ini@^1.3.4:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
+iniparser@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/iniparser/-/iniparser-1.0.5.tgz#836d6befe6dfbfcee0bccf1cf9f2acc7027f783d"
+  integrity sha1-g21r7+bfv87gvM8c+fKsxwJ/eD0=
+
 inquirer@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.1.0.tgz#1298a01859883e17c7264b82870ae1034f92dd29"


### PR DESCRIPTION
This PR does 2 unrelated things (sorry):

   1. Attempt to automatically derive the repository name, instead of hard-coding it.
   2. Remove the `window` and `localStorage` mocks, as they aren't needed to avoid failures when building static pages. What's more, the `window` mock was causing the build to explode when using the `serverless` build target. So this PR also closes #7.

I also raised https://github.com/vercel/next-site/issues/715 because the Next.js documentation is confusing on the subject of whether you should or shouldn't target `serverless` all the time.