### PR TITLE
Custom `Image` loader; `pathPrefix` for paths

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -32,6 +32,10 @@ const nextConfig = {
    */
   basePath: pathPrefix,
 
+  images: {
+    loader: 'custom',
+  },
+
   /**
    * Set custom `process.env.SOMETHING` values to use in the application.
    * You can do this with Webpack's `DefinePlugin`, but this is more concise.

--- a/src/components/starter/doc_panel.tsx
+++ b/src/components/starter/doc_panel.tsx
@@ -2,8 +2,12 @@ import { FunctionComponent } from 'react';
 import Head from 'next/head';
 import Image from 'next/image';
 import { EuiPanel, useEuiTheme } from '@elastic/eui';
+import { imageLoader } from '../../lib/loader';
 import { useTheme } from '../theme';
 import { docPanelStyles } from './doc_panel.styles';
+import Pattern1 from '../../../public/images/patterns/pattern-1.svg';
+import Pattern2Light from '../../../public/images/patterns/pattern-2-light.svg';
+import Pattern2Dark from '../../../public/images/patterns/pattern-2-dark.svg';
 
 const DocPanel: FunctionComponent = ({ children }) => {
   const { euiTheme } = useEuiTheme();
@@ -11,7 +15,7 @@ const DocPanel: FunctionComponent = ({ children }) => {
 
   const styles = docPanelStyles(euiTheme);
 
-  const pattern2 = `/images/patterns/pattern-2-${colorMode}.svg`;
+  const Pattern2 = colorMode === 'dark' ? Pattern2Dark : Pattern2Light;
 
   return (
     <>
@@ -24,12 +28,19 @@ const DocPanel: FunctionComponent = ({ children }) => {
           <Image
             width={165}
             height={130}
-            src="/images/patterns/pattern-1.svg"
+            src={Pattern1}
             alt=""
+            loader={imageLoader}
           />
         </span>
         <span css={styles.pattern2}>
-          <Image width={165} height={130} src={pattern2} alt="" />
+          <Image
+            width={165}
+            height={130}
+            src={Pattern2}
+            alt=""
+            loader={imageLoader}
+          />
         </span>
         <div css={styles.content}>{children}</div>
       </EuiPanel>

--- a/src/components/starter/header.tsx
+++ b/src/components/starter/header.tsx
@@ -8,8 +8,10 @@ import {
   EuiToolTip,
   EuiIcon,
 } from '@elastic/eui';
+import { imageLoader } from '../../lib/loader';
 import ThemeSwitcher from './theme_switcher';
 import { headerStyles } from './header.styles';
+import Logo from '../../../public/images/logo-eui.svg';
 
 const Header = () => {
   const { euiTheme } = useEuiTheme();
@@ -28,8 +30,9 @@ const Header = () => {
                 <Image
                   width={24}
                   height={24}
-                  src="/images/logo-eui.svg"
+                  src={Logo}
                   alt=""
+                  loader={imageLoader}
                 />
                 <EuiTitle size="xxs">
                   <span>NextJS EUI Starter</span>

--- a/src/components/starter/home_illustration.tsx
+++ b/src/components/starter/home_illustration.tsx
@@ -2,18 +2,18 @@ import { FunctionComponent } from 'react';
 import { useTheme } from '../theme';
 import Image from 'next/image';
 import { useEuiTheme } from '@elastic/eui';
+import { imageLoader } from '../../lib/loader';
 import { homeIllustration } from './home_illustration.styles';
+import IllustrationLight from '../../../public/images/home/illustration-eui-hero-500-shadow.svg';
+import IllustrationDark from '../../../public/images/home/illustration-eui-hero-500-darkmode-shadow.svg';
 
 const HomeIllustration: FunctionComponent = () => {
   const { colorMode } = useTheme();
   const { euiTheme } = useEuiTheme();
   const styles = homeIllustration(euiTheme);
 
-  const isDarkTheme = colorMode === 'dark';
-
-  const illustration = isDarkTheme
-    ? '/images/home/illustration-eui-hero-500-darkmode-shadow.svg'
-    : '/images/home/illustration-eui-hero-500-shadow.svg';
+  const Illustration =
+    colorMode === 'dark' ? IllustrationDark : IllustrationLight;
 
   return (
     <div css={styles.homeIllustration}>
@@ -24,7 +24,13 @@ const HomeIllustration: FunctionComponent = () => {
         <div className="homeIllustration__BottomRightCorner" />
 
         <div className="homeIllustration__EffectSVG">
-          <Image width={500} height={500} src={illustration} alt="" />
+          <Image
+            width={500}
+            height={500}
+            src={Illustration}
+            alt=""
+            loader={imageLoader}
+          />
         </div>
       </div>
     </div>

--- a/src/components/starter/home_templates.tsx
+++ b/src/components/starter/home_templates.tsx
@@ -11,14 +11,18 @@ import {
 } from '@elastic/eui';
 import Image from 'next/image';
 import Link from 'next/link';
+import { imageLoader } from '../../lib/loader';
 import { useTheme } from '../theme';
 import { homeTemplates } from './home_templates.styles';
+import Pattern1 from '../../../public/images/patterns/pattern-1.svg';
+import Pattern2Light from '../../../public/images/patterns/pattern-2-light.svg';
+import Pattern2Dark from '../../../public/images/patterns/pattern-2-dark.svg';
 
 const HomeTemplates: FunctionComponent = () => {
   const { colorMode } = useTheme();
   const { euiTheme } = useEuiTheme();
 
-  const pattern2 = `/images/patterns/pattern-2-${colorMode}.svg`;
+  const Pattern2 = colorMode === 'dark' ? Pattern2Dark : Pattern2Light;
 
   const styles = homeTemplates(euiTheme);
 
@@ -28,12 +32,19 @@ const HomeTemplates: FunctionComponent = () => {
         <Image
           width={165 / 2}
           height={130 / 2}
-          src="/images/patterns/pattern-1.svg"
+          src={Pattern1}
           alt=""
+          loader={imageLoader}
         />
       </span>
       <span css={styles.circle2}>
-        <Image width={165 / 2} height={130 / 2} src={pattern2} alt="" />
+        <Image
+          width={165 / 2}
+          height={130 / 2}
+          src={Pattern2}
+          alt=""
+          loader={imageLoader}
+        />
       </span>
     </>
   );

--- a/src/layouts/docs.tsx
+++ b/src/layouts/docs.tsx
@@ -9,6 +9,8 @@ import {
 import ThemeSwitcher from '../components/chrome/theme_switcher';
 import { docsLayout } from './docs.styles';
 
+const pathPrefix = process.env.PATH_PREFIX;
+
 const DocsLayout = ({ pageHeader, children }) => {
   const sideNav = [
     {
@@ -39,7 +41,10 @@ const DocsLayout = ({ pageHeader, children }) => {
         sections={[
           {
             items: [
-              <EuiHeaderLogo key="elastic-docs" iconType="logoElastic" href="/">
+              <EuiHeaderLogo
+                key="elastic-docs"
+                iconType="logoElastic"
+                href={`${pathPrefix}`}>
                 Elastic docs
               </EuiHeaderLogo>,
             ],

--- a/src/layouts/kibana_collapsible_nav.tsx
+++ b/src/layouts/kibana_collapsible_nav.tsx
@@ -17,8 +17,9 @@ import {
 import find from 'lodash/find';
 import findIndex from 'lodash/findIndex';
 import { css } from '@emotion/react';
-
 import ThemeSwitcher from '../components/chrome/theme_switcher';
+
+const pathPrefix = process.env.PATH_PREFIX;
 
 const TopLinks: EuiPinnableListGroupItemProps[] = [
   {
@@ -217,7 +218,10 @@ const CollapsibleNav = () => {
         sections={[
           {
             items: [
-              <EuiHeaderLogo key="ops" iconType="logoElastic" href="/">
+              <EuiHeaderLogo
+                key="ops"
+                iconType="logoElastic"
+                href={`${pathPrefix}`}>
                 Elastic
               </EuiHeaderLogo>,
             ],

--- a/src/lib/loader.ts
+++ b/src/lib/loader.ts
@@ -1,0 +1,4 @@
+import { ImageLoader } from 'next/image';
+
+export const imageLoader: ImageLoader = ({ src, width, quality }) =>
+  `${src}?w=${width}&q=${quality || 75}`;

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -42,12 +42,12 @@ export default class MyDocument extends Document {
   render(): ReactElement {
     const isLocalDev = process.env.NODE_ENV === 'development';
 
-    const favicon16Prod = '/images/favicon/prod/favicon-16x16.png';
-    const favicon32Prod = '/images/favicon/prod/favicon-32x32.png';
-    const favicon96Prod = '/images/favicon/prod/favicon-96x96.png';
-    const favicon16Dev = '/images/favicon/dev/favicon-16x16.png';
-    const favicon32Dev = '/images/favicon/dev/favicon-32x32.png';
-    const favicon96Dev = '/images/favicon/dev/favicon-96x96.png';
+    const favicon16Prod = `${pathPrefix}/images/favicon/prod/favicon-16x16.png`;
+    const favicon32Prod = `${pathPrefix}/images/favicon/prod/favicon-32x32.png`;
+    const favicon96Prod = `${pathPrefix}/images/favicon/prod/favicon-96x96.png`;
+    const favicon16Dev = `${pathPrefix}/images/favicon/dev/favicon-16x16.png`;
+    const favicon32Dev = `${pathPrefix}/images/favicon/dev/favicon-32x32.png`;
+    const favicon96Dev = `${pathPrefix}/images/favicon/dev/favicon-96x96.png`;
 
     return (
       <Html lang="en">


### PR DESCRIPTION
Resolves static asset issues when attempting to deploy to GitHub pages

* Import image files directly where possible
* Use the custom `loader` prop on `<Image />`
* Use `pathPrefix` where relative paths are required