### PR TITLE
Adding meta tags and renaming NextJS to Next.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 <p align="center">
-  <img src="src/images/logo_elastic.png" width="60"  alt="Elastic Logo"/>
+  <img src="https://repository-images.githubusercontent.com/233832487/cddf0ff5-a35f-4380-8912-1c9f365366a8" alt="EUI Next.js Starter"/>
 </p>
 
-<h1 align="center">
-  Elastic's Next.js EUI Starter
-</h1>
+# Elastic's Next.js EUI Starter
+
 
 Jump right in to building prototypes with [EUI](https://github.com/elastic/eui).
 

--- a/src/components/starter/header.tsx
+++ b/src/components/starter/header.tsx
@@ -32,7 +32,7 @@ const Header = () => {
                   alt=""
                 />
                 <EuiTitle size="xxs">
-                  <span>NextJS EUI Starter</span>
+                  <span>Next.js EUI Starter</span>
                 </EuiTitle>
               </a>
             </Link>,

--- a/src/components/starter/home_hero.tsx
+++ b/src/components/starter/home_hero.tsx
@@ -20,17 +20,17 @@ const HomeHero: FunctionComponent = () => {
     <EuiFlexGroup alignItems="center" css={styles.container}>
       <EuiFlexItem>
         <EuiTitle size="l" css={styles.title}>
-          <h1>NextJS EUI Starter</h1>
+          <h1>Next.js EUI Starter</h1>
         </EuiTitle>
         <EuiTitle size="s" css={styles.subtitle}>
-          <h2>Welcome to NextJS EUI Starter</h2>
+          <h2>Welcome to Next.js EUI Starter</h2>
         </EuiTitle>
 
         <EuiText grow={false} css={styles.description}>
           <p>
-            The NextJS Starter uses{' '}
+            The Next.js Starter uses{' '}
             <EuiLink external={true} href="https://nextjs.org/">
-              NextJS
+              Next.js
             </EuiLink>
             ,{' '}
             <EuiLink href="https://elastic.github.io/eui/" external={true}>
@@ -43,7 +43,8 @@ const HomeHero: FunctionComponent = () => {
               Emotion
             </EuiLink>{' '}
             to help you make prototypes. You just need to know a few basic
-            NextJS concepts and how to use EUI and you&apos;re ready to ship it!
+            Next.js concepts and how to use EUI and you&apos;re ready to ship
+            it!
           </p>
 
           <Link href="/getting-started" passHref>

--- a/src/components/starter/home_why.tsx
+++ b/src/components/starter/home_why.tsx
@@ -42,7 +42,7 @@ const HomeWhy: FunctionComponent = () => {
             display="transparent"
             hasBorder
             title="Prototype"
-            description="This starter comes with NextJS, EUI, and Emotion so these give an easy setup to prototype."
+            description="This starter comes with Next.js, EUI, and Emotion so these give an easy setup to prototype."
           />
         </EuiFlexItem>
         <EuiFlexItem>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -17,7 +17,7 @@ import { globalStyes } from '../styles/global.styles';
 const EuiApp: FunctionComponent<AppProps> = ({ Component, pageProps }) => (
   <>
     <Head>
-      {/* You can override this in other pages - see page-2.tsx for an example */}
+      {/* You can override this in other pages - see index.tsx for an example */}
       <title>Next.js EUI Starter</title>
     </Head>
     <Global styles={globalStyes} />

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -36,7 +36,7 @@ function themeLink(theme: Theme): ReactElement {
  * inject the available EUI theme files.  Only the `light` theme is
  * initially enabled.
  *
- * @see https://Next.js.org/docs/advanced-features/custom-document
+ * @see https://nextjs.org/docs/advanced-features/custom-document
  */
 export default class MyDocument extends Document {
   render(): ReactElement {

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -36,7 +36,7 @@ function themeLink(theme: Theme): ReactElement {
  * inject the available EUI theme files.  Only the `light` theme is
  * initially enabled.
  *
- * @see https://nextjs.org/docs/advanced-features/custom-document
+ * @see https://Next.js.org/docs/advanced-features/custom-document
  */
 export default class MyDocument extends Document {
   render(): ReactElement {
@@ -52,7 +52,26 @@ export default class MyDocument extends Document {
     return (
       <Html lang="en">
         <Head>
+          <meta
+            name="description"
+            content="The Next.js EUI Starter uses Next.js, EUI library, and Emotion to help you make prototypes. You just need to know a few basic Next.js concepts and how to use EUI and you're ready to ship it!"
+          />
+          <meta property="og:title" content="Elastic UI" />
+          <meta
+            property="og:description"
+            content="The Next.js EUI Starter uses Next.js, EUI library, and Emotion to help you make prototypes. You just need to know a few basic Next.js concepts and how to use EUI and you're ready to ship it!"
+          />
+          <meta
+            property="og:image"
+            content="https://repository-images.githubusercontent.com/233832487/cddf0ff5-a35f-4380-8912-1c9f365366a8"
+          />
+          <meta
+            property="og:url"
+            content="https://elastic.github.io/next-eui-starter/"
+          />
+          <meta name="twitter:card" content="summary_large_image" />
           <meta name="eui-styles-global" />
+
           {themeConfig.availableThemes.map(each => themeLink(each))}
 
           <link


### PR DESCRIPTION
I'm adding meta tags and using the `https://github.com/elastic/next-eui-starter/settings` social image preview as the `<meta property="og:image"... />`:

<img width="677" alt="Screenshot 2022-04-04 at 19 44 25" src="https://user-images.githubusercontent.com/2750668/161610920-4370e18c-7e14-4428-bca4-17d08eae3ad8.png">

I'm also renaming all `NextJS` text references to `Next.js`.