### PR TITLE
Fix links not working in prod

### DIFF
--- a/src/layouts/docs.tsx
+++ b/src/layouts/docs.tsx
@@ -44,7 +44,7 @@ const DocsLayout = ({ pageHeader, children }) => {
               <EuiHeaderLogo
                 key="elastic-docs"
                 iconType="logoElastic"
-                href={`${pathPrefix}`}>
+                href={`${pathPrefix}/docs`}>
                 Elastic docs
               </EuiHeaderLogo>,
             ],

--- a/src/layouts/docs.tsx
+++ b/src/layouts/docs.tsx
@@ -20,12 +20,12 @@ const DocsLayout = ({ pageHeader, children }) => {
         {
           name: 'Home',
           id: htmlIdGenerator('basicExample')(),
-          href: '/docs/',
+          href: `${pathPrefix}/docs/`,
         },
         {
           name: 'Page 2',
           id: htmlIdGenerator('basicExample')(),
-          href: '/docs/page-2',
+          href: `${pathPrefix}/docs/page-2`,
         },
       ],
     },

--- a/src/layouts/kibana_collapsible_nav.tsx
+++ b/src/layouts/kibana_collapsible_nav.tsx
@@ -27,14 +27,14 @@ const TopLinks: EuiPinnableListGroupItemProps[] = [
     iconType: 'home',
     isActive: true,
     'aria-current': true,
-    href: '/kibana',
+    href: 'kibana',
     pinnable: false,
   },
 ];
 
 const KibanaLinks: EuiPinnableListGroupItemProps[] = [
-  { label: 'Discover', href: '/kibana/discover' },
-  { label: 'Dashboard', href: '/kibana/dashboards' },
+  { label: 'Discover', href: `${pathPrefix}/kibana/discover` },
+  { label: 'Dashboard', href: `${pathPrefix}/kibana/dashboards` },
 ];
 
 const CollapsibleNav = () => {
@@ -219,7 +219,7 @@ const CollapsibleNav = () => {
           {
             items: [
               <EuiHeaderLogo
-                key="ops"
+                key="elastic-logo"
                 iconType="logoElastic"
                 href={`${pathPrefix}`}>
                 Elastic

--- a/src/layouts/kibana_collapsible_nav.tsx
+++ b/src/layouts/kibana_collapsible_nav.tsx
@@ -27,7 +27,7 @@ const TopLinks: EuiPinnableListGroupItemProps[] = [
     iconType: 'home',
     isActive: true,
     'aria-current': true,
-    href: 'kibana',
+    href: `${pathPrefix}/kibana`,
     pinnable: false,
   },
 ];
@@ -221,7 +221,7 @@ const CollapsibleNav = () => {
               <EuiHeaderLogo
                 key="elastic-logo"
                 iconType="logoElastic"
-                href={`${pathPrefix}`}>
+                href={`${pathPrefix}/kibana`}>
                 Elastic
               </EuiHeaderLogo>,
             ],


### PR DESCRIPTION
It seems that some links were not working in prod because I didn't use `pathPrefix` to tell Next where the files will be served.