### PR TITLE
Converting Kibana examples from TS to JS

### DIFF
--- a/src/layouts/kibana_collapsible_nav.tsx
+++ b/src/layouts/kibana_collapsible_nav.tsx
@@ -35,6 +35,7 @@ const TopLinks: EuiPinnableListGroupItemProps[] = [
 const KibanaLinks: EuiPinnableListGroupItemProps[] = [
   { label: 'Discover', href: `${pathPrefix}/kibana/discover` },
   { label: 'Dashboard', href: `${pathPrefix}/kibana/dashboards` },
+  { label: 'Maps', href: `${pathPrefix}/kibana/maps` },
 ];
 
 const CollapsibleNav = () => {

--- a/src/pages/kibana/dashboards.js
+++ b/src/pages/kibana/dashboards.js
@@ -1,13 +1,23 @@
-import { FunctionComponent } from 'react';
 import Link from 'next/link';
-import { EuiLink, EuiText } from '@elastic/eui';
+import { EuiLink, EuiText, EuiButton } from '@elastic/eui';
 import KibanaLayout from '../../layouts/kibana';
 
-const Discover: FunctionComponent = () => {
+const Discover = () => {
   return (
     <KibanaLayout
       pageHeader={{
-        pageTitle: 'Discover',
+        pageTitle: 'Dashboards',
+        rightSideItems: [
+          <EuiButton
+            color="primary"
+            fill
+            onClick={() => {
+              console.log('Create dashboard');
+            }}
+            key="create-dashboard">
+            Create dashboard
+          </EuiButton>,
+        ],
       }}>
       <EuiText>
         <p>

--- a/src/pages/kibana/discover.js
+++ b/src/pages/kibana/discover.js
@@ -1,24 +1,12 @@
-import { FunctionComponent } from 'react';
 import Link from 'next/link';
-import { EuiLink, EuiText, EuiButton } from '@elastic/eui';
+import { EuiLink, EuiText } from '@elastic/eui';
 import KibanaLayout from '../../layouts/kibana';
 
-const Discover: FunctionComponent = () => {
+const Discover = () => {
   return (
     <KibanaLayout
       pageHeader={{
-        pageTitle: 'Dashboards',
-        rightSideItems: [
-          <EuiButton
-            color="primary"
-            fill
-            onClick={() => {
-              console.log('Create dashboard');
-            }}
-            key="create-dashboard">
-            Create dashboard
-          </EuiButton>,
-        ],
+        pageTitle: 'Discover',
       }}>
       <EuiText>
         <p>

--- a/src/pages/kibana/index.js
+++ b/src/pages/kibana/index.js
@@ -1,8 +1,7 @@
-import { FunctionComponent } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiCard, EuiIcon } from '@elastic/eui';
 import KibanaLayout from '../../layouts/kibana';
 
-const Index: FunctionComponent = () => {
+const Index = () => {
   return (
     <KibanaLayout
       template="empty"

--- a/src/pages/kibana/index.js
+++ b/src/pages/kibana/index.js
@@ -26,8 +26,8 @@ const Index = () => {
 
         <EuiFlexItem>
           <EuiCard
-            icon={<EuiIcon size="xxl" type="lensApp" />}
-            title="Lens"
+            icon={<EuiIcon size="xxl" type="gisApp" />}
+            title="Maps"
             description="Example of a card's description. Stick to one or two sentences."
           />
         </EuiFlexItem>

--- a/src/pages/kibana/maps.js
+++ b/src/pages/kibana/maps.js
@@ -1,0 +1,25 @@
+import { EuiText } from '@elastic/eui';
+import KibanaLayout from '../../layouts/kibana';
+
+const Maps = () => {
+  return (
+    <KibanaLayout
+      pageHeader={{
+        pageTitle: 'Maps',
+      }}>
+      <EuiText>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean a erat
+          sed arcu imperdiet eleifend eu vel ante. Nam dapibus lacus id
+          efficitur luctus. Nunc vitae viverra erat, at euismod metus. Nam nec
+          nulla ornare, aliquam arcu in, luctus diam. Phasellus convallis lorem
+          fringilla, dapibus lectus in, pretium dui. Pellentesque massa nulla,
+          tempus ut elit at, scelerisque commodo eros. Proin interdum libero
+          aliquam, volutpat justo ut, posuere nulla.
+        </p>
+      </EuiText>
+    </KibanaLayout>
+  );
+};
+
+export default Maps;


### PR DESCRIPTION
One of the feedbacks we had from the working group **Coded Prototypes** is that is difficult to use Typescript.  So I tested and renamed one of the page's folders to use `*.js` instead of `*.tsx`. 

It seems to work well, and we can merge this so that consumers can see that they can use `*.js` for faster prototypes.

But @cindychangy mentioned that she found some issues using this starter with `*.js` files so I'll add her as a reviewer. 