### PR TITLE
Include core-js and regeneratorruntime polyfills

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "url": "https://github.com/elastic/next-eui-starter/issues"
   },
   "dependencies": {
-    "@elastic/eui": "^55.1.0"
+    "@elastic/eui": "^55.1.0",
+    "core-js": "^3.25.1",
+    "regenerator-runtime": "^0.13.9"
   },
   "devDependencies": {
     "@elastic/datemath": "^5.0.3",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,3 +1,5 @@
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 import { FunctionComponent } from 'react';
 import { AppProps } from 'next/app';
 import Head from 'next/head';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1108,6 +1108,11 @@ core-js-pure@^3.20.2:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.21.1.tgz#8c4d1e78839f5f46208de7230cebfb72bc3bdb51"
   integrity sha512-12VZfFIu+wyVbBebyHmRTuEE/tZrB4tJToWcwAMcsp3h4+sHR+fMJWbKpYiCRWlhFBq+KNyO8rIV9rTkeVmznQ==
 
+core-js@^3.25.1:
+  version "3.25.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.25.1.tgz#5818e09de0db8956e16bf10e2a7141e931b7c69c"
+  integrity sha512-sr0FY4lnO1hkQ4gLDr24K0DGnweGO1QwSj5BpfQjpSJPdqWalja4cTps29Y/PJVG/P7FYlPDkH3hO+Tr0CvDgQ==
+
 cosmiconfig@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-6.0.0.tgz#da4fee853c52f6b1e6935f41c1a2fc50bd4a9982"
@@ -3233,7 +3238,7 @@ refractor@^3.5.0:
     parse-entities "^2.0.0"
     prismjs "~1.27.0"
 
-regenerator-runtime@^0.13.4:
+regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==


### PR DESCRIPTION
Closes #70 by including core-js and regeneratorruntime polyfills. I tested this by adding EuiDataGrid to _pages/index.tsx_, confirmed the error, added the polyfills, confirmed no error.

```typescript
<EuiDataGrid
  aria-label="hello"
  columns={[
    {
      id: 'test',
    },
  ]}
  columnVisibility={{
    visibleColumns: ['test'],
    setVisibleColumns: () => {},
  }}
  rowCount={10}
  renderCellValue={(stuff) => <span>{stuff.rowIndex}</span>}
/>
```

I also tried upgrading the EUI version to 67.0.0 but that's causing next to run out of memory during compilation, have to follow up on that one.